### PR TITLE
New tsv parser for interproscan files 

### DIFF
--- a/cli/genenotebook.js
+++ b/cli/genenotebook.js
@@ -368,8 +368,14 @@ addInterproscan
   .description('Add InterProScan results to a running GeneNoteBook server')
   .usage('[options] <InterProScan gff3 output file>')
   .arguments('<file>')
-  .option('-u, --username <username>', 'GeneNoteBook admin username')
-  .option('-p, --password <password>', 'GeneNoteBook admin password')
+  .requiredOption(
+    '-u, --username <adminUsername>',
+    'GeneNoteBook admin username'
+  )
+  .requiredOption(
+    '-p, --password <adminPassword>',
+    'GeneNoteBook admin password'
+  )
   .option(
     '--port [port]',
     'Port on which GeneNoteBook is running. Default: 3000'
@@ -381,10 +387,22 @@ addInterproscan
     if (!(fileName && username && password)) {
       addInterproscan.help();
     }
-    new GeneNoteBookConnection({ username, password, port }).call(
-      'addInterproscan',
-      { fileName }
-    );
+
+    const extentionFile = path.extname(file);
+
+    new GeneNoteBookConnection({ username, password, port })
+      .call('addInterproscan', {
+        fileName,
+        formatOutput: extentionFile,
+      });
+  })
+  .on('--help', function() {
+    console.log(`
+Example:
+    genenotebook add interproscan testdata.iprscan.gff3 -u admin -p admin
+or
+    genenotebook add interproscan testdata.iprscan.tsv -u admin -p admin
+    `);
   })
   .exitOverride(customExitOverride(addInterproscan));
 

--- a/cli/genenotebook.js
+++ b/cli/genenotebook.js
@@ -381,8 +381,8 @@ addInterproscan
     'Port on which GeneNoteBook is running. Default: 3000',
   )
   .option(
-    '--parser [parser]',
-    `Choose a parser for an InterProScan output file. Can parse .gff3 and .tsv
+    '--format [parser]',
+    `Choose a parser for the interproscan output files. Parses .gff3 and .tsv
     extensions.`,
   )
   .action((file, { username, password, port = 3000, parser }) => {
@@ -401,7 +401,7 @@ addInterproscan
     } else if (['tsv', 'gff3'].includes(extensionFile)) {
       parserType = extensionFile;
     } else {
-      logger.error('--parser parameter is not defined');
+      logger.error('--format parameter is not defined');
       addInterproscan.help();
     }
 
@@ -416,7 +416,7 @@ addInterproscan
 Example:
     genenotebook add interproscan testdata.iprscan.gff3 -u admin -p admin
 or
-    genenotebook add interproscan testdata.iprscan --parser tsv -u admin -p admin
+    genenotebook add interproscan testdata.iprscan --format tsv -u admin -p admin
     `);
   })
   .exitOverride(customExitOverride(addInterproscan));

--- a/cli/genenotebook.js
+++ b/cli/genenotebook.js
@@ -385,7 +385,7 @@ addInterproscan
     `Choose a parser for the interproscan output files. Parses .gff3 and .tsv
     extensions.`,
   )
-  .action((file, { username, password, port = 3000, parser }) => {
+  .action((file, { username, password, port = 3000, format }) => {
     if (typeof file !== 'string') addInterproscan.help();
 
     const fileName = path.resolve(file);
@@ -393,16 +393,26 @@ addInterproscan
       addInterproscan.help();
     }
 
-    let parserType;
+    const parserAccepted = ['tsv', 'gff3', 'xml'];
     const extensionFile = path.extname(file).replace(/\./g, '');
+    let parserType = format;
 
-    if (['tsv', 'gff3'].includes(parser)) {
-      parserType = parser;
-    } else if (['tsv', 'gff3'].includes(extensionFile)) {
-      parserType = extensionFile;
+    if (parserType) {
+      if (!parserAccepted.includes(parserType)) {
+        logger.error(`
+Error: unknow format : ${parserType}. To specify --format, choose a format
+compatible with InterProScan e.g : "gff3", "tsv" or "xml".`);
+        addInterproscan.help();
+      }
     } else {
-      logger.error('--format parameter is not defined');
-      addInterproscan.help();
+      if (parserAccepted.includes(extensionFile)) {
+        parserType = extensionFile;
+      } else {
+        logger.error(`
+Error : unknow file extension : ${extensionFile}. Must specify --format when
+file extension is not "tsv", "gff3" or "xml".`);
+        addInterproscan.help();
+      }
     }
 
     new GeneNoteBookConnection({ username, password, port })

--- a/cli/genenotebook.js
+++ b/cli/genenotebook.js
@@ -393,14 +393,15 @@ addInterproscan
       addInterproscan.help();
     }
 
-    const extFile = path.extname(file).replace(/\./g, '');
     let parserType;
+    const extensionFile = path.extname(file).replace(/\./g, '');
+
     if (['tsv', 'gff3'].includes(parser)) {
       parserType = parser;
-    } else if (['tsv', 'gff3'].includes(extFile)) {
-      parserType = extFile;
+    } else if (['tsv', 'gff3'].includes(extensionFile)) {
+      parserType = extensionFile;
     } else {
-      logger.error('--parser parameter is not provided');
+      logger.error('--parser parameter is not defined');
       addInterproscan.help();
     }
 

--- a/imports/api/genes/addInterproscan.js
+++ b/imports/api/genes/addInterproscan.js
@@ -1,206 +1,56 @@
-import { Meteor } from 'meteor/meteor';
+import jobQueue, { Job } from '/imports/api/jobqueue/jobqueue.js';
 import { ValidatedMethod } from 'meteor/mdg:validated-method';
-import { Roles } from 'meteor/alanning:roles';
-
-import SimpleSchema from 'simpl-schema';
-import Papa from 'papaparse';
-import fs from 'fs';
-
-// import { chunk } from 'lodash';
-
 import { Genes } from '/imports/api/genes/geneCollection.js';
-// import { Interpro } from '/imports/api/genes/interpro_collection.js';
 import logger from '/imports/api/util/logger.js';
+import { Roles } from 'meteor/alanning:roles';
+import SimpleSchema from 'simpl-schema';
+import { Meteor } from 'meteor/meteor';
 
-import {
-  parseAttributeString, debugParseAttributeString, DBXREF_REGEX,
-} from '/imports/api/util/util.js';
-
-const logAttributeError = ({
-  lineNumber, line, attributeString, error,
-}) => {
-  logger.warn(`Error line ${lineNumber}`);
-  logger.warn(line.join('\t'));
-  logger.warn(attributeString);
-  logger.warn(debugParseAttributeString(attributeString));
-  throw new Meteor.Error(error);
-};
-
-class InterproscanProcessor {
+class InitializeGenes {
   constructor() {
     this.bulkOp = Genes.rawCollection().initializeUnorderedBulkOp();
-    this.lineNumber = 0;
   }
 
-  parse = (line) => {
-    this.lineNumber += 1;
-    const [seqId, source, type, start, end,
-      score, , , attributeString] = line;
-
-    if (type === 'protein_match') {
-      if (typeof attributeString !== 'undefined') {
-        let attributes;
-        try {
-          attributes = parseAttributeString(attributeString);
-        } catch (error) {
-          logAttributeError({
-            lineNumber: this.lineNumber,
-            line,
-            attributeString,
-            error,
-          });
-        }
-
-        const dbUpdate = { $addToSet: {} };
-
-        const {
-          Name, Dbxref: _dbxref = [], Ontology_term = [],
-          signature_desc = [],
-        } = attributes;
-        const Dbxref = _dbxref
-          .filter((xref) => DBXREF_REGEX.combined.test(xref));
-
-        const proteinDomain = {
-          start, end, source, score, name: Name[0],
-        };
-
-        const interproIds = Dbxref
-          .filter((xref) => /InterPro/.test(xref))
-          .map((interproId) => {
-            const [, id] = interproId.split(':');
-            return id;
-          });
-
-        if (interproIds.length) {
-          proteinDomain.interproId = interproIds[0];
-        } else {
-          proteinDomain.interproId = 'Unintegrated signature';
-        }
-
-        if (Dbxref.length) {
-          proteinDomain.Dbxref = Dbxref;
-          dbUpdate.$addToSet['attributes.Dbxref'] = { $each: Dbxref };
-        }
-
-        if (signature_desc.length) {
-          proteinDomain.signature_desc = signature_desc[0];
-        }
-
-        if (Ontology_term.length) {
-          proteinDomain.Ontology_term = Ontology_term;
-          dbUpdate.$addToSet['attributes.Ontology_term'] = {
-            $each: Ontology_term,
-          };
-        }
-
-        dbUpdate.$addToSet['subfeatures.$.protein_domains'] = proteinDomain;
-
-        this.bulkOp.find({ 'subfeatures.ID': seqId }).update(dbUpdate);
-      } else {
-        logger.warn('Undefined attributes:');
-        logger.warn(line.join('\t'));
-      }
-    }
-  }
-
-  finalize = () => this.bulkOp.execute()
+  finalize = () => {
+    logger.log('Close the dataset.');
+    this.bulkOp.execute();
+  };
 }
-/*
-const scanInterproApi = interproIds => {
-  logger.log(interproIds)
-  const date = new Date();
-  const requests = chunk([...interproIds],10).map(ids => {
-    logger.log(ids);
-    return request(`http://www.ebi.ac.uk/Tools/dbfetch/dbfetch/interpro/${ids.join(',')}/tab`)
-  })
-  Promise.all(requests).then(results => {
-    results.forEach(result => {
-      const lines = result.split('\n');
-      const dbVersion = lines[0].split()[1];
-      lines.forEach((line, lineIndex) => {
-        if ( line[0] !== '#' ) {
-          const [interproId, interproType, shortName, name] = line.split('\t');
-          Interpro.update({
-            interproId
-          },{
-            $set: {
-              interproId, interproType, shortName, name, dbVersion, date
-            }
-          },
-          {
-            upsert: true
-          })
-        }
-      })
-    })
-  }).catch(error => {
-    logger.log(error)
-    throw new Meteor.Error(error)
-  })
-}
-*/
-const parseInterproscanGff = (fileName) => new Promise((resolve, reject) => {
-  logger.log('addInterproscan', fileName);
-
-  let lineNumber = 0;
-
-  const fileHandle = fs.readFileSync(fileName, { encoding: 'binary' });
-
-  // const allInterproIds = new Set();
-
-  const lineProcessor = new InterproscanProcessor();
-
-  Papa.parse(fileHandle, {
-    delimiter: '\t',
-    dynamicTyping: true,
-    skipEmptyLines: true,
-    error(error) {
-      reject(error);
-    },
-    step({ data }, parser) {
-      lineNumber += 1;
-      if (lineNumber % 100 === 0) {
-        logger.debug(`Processed ${lineNumber} lines`);
-      }
-      if (data[0] === '#') {
-        if (/fasta/i.test(data[0])) {
-          logger.log('Encountered fasta section, stopped parsing');
-          parser.abort();
-        }
-      } else {
-        lineProcessor.parse(data);
-      }
-    },
-    complete() {
-      logger.log('Executing bulk operation');
-      const bulkOpResults = lineProcessor.finalize();
-      logger.log('Finished');
-      resolve(bulkOpResults);
-    },
-  });
-});
 
 const addInterproscan = new ValidatedMethod({
   name: 'addInterproscan',
   validate: new SimpleSchema({
-    fileName: String,
+    fileName: { type: String },
+    formatOutput: {
+      type: String,
+      allowedValues: ['.tsv', '.gff3'],
+    },
   }).validator(),
   applyOptions: {
     noRetry: true,
   },
-  run({ fileName }) {
+  run({ fileName, formatOutput }) {
     if (!this.userId) {
       throw new Meteor.Error('not-authorized');
     }
     if (!Roles.userIsInRole(this.userId, 'admin')) {
       throw new Meteor.Error('not-authorized');
     }
-    return parseInterproscanGff(fileName)
-      .catch((error) => {
-        logger.warn(error);
-        throw new Meteor.Error(error);
-      });
+
+    const job = new Job(jobQueue, 'addInterproscan', { fileName, formatOutput });
+    const jobId = job.priority('high').save();
+
+    // Continue with synchronous processing
+    let { status } = job.doc;
+    logger.debug(`Job status: ${status}`);
+    while (status !== 'completed') {
+      const { doc } = job.refresh();
+      status = doc.status;
+    }
+
+    return { result: job.doc.result };
   },
 });
 
 export default addInterproscan;
+export { InitializeGenes };

--- a/imports/api/genes/addInterproscan.js
+++ b/imports/api/genes/addInterproscan.js
@@ -6,7 +6,7 @@ import { Roles } from 'meteor/alanning:roles';
 import SimpleSchema from 'simpl-schema';
 import { Meteor } from 'meteor/meteor';
 
-class InitializeGenes {
+class InterproscanProcessor {
   constructor() {
     this.bulkOp = Genes.rawCollection().initializeUnorderedBulkOp();
   }
@@ -21,15 +21,15 @@ const addInterproscan = new ValidatedMethod({
   name: 'addInterproscan',
   validate: new SimpleSchema({
     fileName: { type: String },
-    formatOutput: {
+    parser: {
       type: String,
-      allowedValues: ['.tsv', '.gff3'],
+      allowedValues: ['tsv', 'gff3'],
     },
   }).validator(),
   applyOptions: {
     noRetry: true,
   },
-  run({ fileName, formatOutput }) {
+  run({ fileName, parser }) {
     if (!this.userId) {
       throw new Meteor.Error('not-authorized');
     }
@@ -37,7 +37,7 @@ const addInterproscan = new ValidatedMethod({
       throw new Meteor.Error('not-authorized');
     }
 
-    const job = new Job(jobQueue, 'addInterproscan', { fileName, formatOutput });
+    const job = new Job(jobQueue, 'addInterproscan', { fileName, parser });
     const jobId = job.priority('high').save();
 
     // Continue with synchronous processing
@@ -53,4 +53,4 @@ const addInterproscan = new ValidatedMethod({
 });
 
 export default addInterproscan;
-export { InitializeGenes };
+export { InterproscanProcessor };

--- a/imports/api/genes/addInterproscan.js
+++ b/imports/api/genes/addInterproscan.js
@@ -11,10 +11,7 @@ class InterproscanProcessor {
     this.bulkOp = Genes.rawCollection().initializeUnorderedBulkOp();
   }
 
-  finalize = () => {
-    logger.log('Close the dataset.');
-    this.bulkOp.execute();
-  };
+  finalize = () => this.bulkOp.execute();
 }
 
 const addInterproscan = new ValidatedMethod({

--- a/imports/api/genes/parseGff3Interproscan.js
+++ b/imports/api/genes/parseGff3Interproscan.js
@@ -1,0 +1,110 @@
+import { InitializeGenes } from '/imports/api/genes/addInterproscan.js';
+import { Meteor } from 'meteor/meteor';
+import logger from '/imports/api/util/logger.js';
+import {
+  parseAttributeString, debugParseAttributeString, DBXREF_REGEX,
+} from '/imports/api/util/util.js';
+
+const logAttributeError = ({
+  lineNumber, line, attributeString, error,
+}) => {
+  logger.warn(`Error line ${lineNumber}`);
+  logger.warn(line.join('\t'));
+  logger.warn(attributeString);
+  logger.warn(debugParseAttributeString(attributeString));
+  throw new Meteor.Error(error);
+};
+
+class ParseGff3File extends InitializeGenes {
+  isProteinMatch = (type) => {
+    if (type === 'protein_match') {
+      return true;
+    }
+    return false;
+  };
+
+  parseAllAttributes = (attributes) => {
+    if (attributes === undefined) {
+      logger.warn('Undefined attributes:');
+      return false;
+    } else {
+      let parseAttributes;
+      try {
+        parseAttributes = parseAttributeString(attributes);
+      } catch (err) {
+        throw new Meteor.Error(err);
+      }
+      return parseAttributes;
+    }
+  };
+
+  parse = (line) => {
+    // Check if the line is different of fasta sequence or others indications.
+    if (!(line[0] === '#' || line.split('\t').length <= 1)) {
+      const [seqId, source, type, start, end, score, , , attributeString, ] = line.split('\t');
+
+      if (this.isProteinMatch(type)) {
+        const attributes = this.parseAllAttributes(attributeString);
+        if (attributes) {
+          const dbUpdate = { $addToSet: {} };
+
+          const {
+            Name,
+            Dbxref: _dbxref = [],
+            OntologyTerm = [],
+            signatureDescription = [],
+          } = attributes;
+
+          const proteinDomain = {
+            start, end, source, score, name: Name[0],
+          };
+
+          // Return only expressions for Interproscan.
+          const Dbxref = _dbxref
+            .filter((xref) => DBXREF_REGEX.combined.test(xref));
+
+          // Retrieve the interposcan ID (e.g: IPR001048 in InterPro:IPR001048).
+          const interproIds = Dbxref
+            .filter((xref) => /InterPro/.test(xref))
+            .map((interproId) => {
+              const [, id] = interproId.split(':');
+              return id;
+            });
+
+          // Initializes the interproId and signatureDescription keys in proteinDomain.
+          if (interproIds.length) {
+            proteinDomain.interproId = interproIds[0];
+          } else {
+            proteinDomain.interproId = 'Unintegrated signature';
+          }
+
+          if (signatureDescription.length) {
+            proteinDomain.signature_desc = signatureDescription[0];
+          }
+
+          // Add array of Dbxref (e.g : InterPro:IPR002376, KEGG:00670+2.1.2.9) in
+          // proteinDomain and database.
+          if (Dbxref.length) {
+            proteinDomain.Dbxref = Dbxref;
+            dbUpdate.$addToSet['attributes.Dbxref'] = { $each: Dbxref };
+          }
+
+          // e.g: GO:0009058","GO:0016742.
+          if (OntologyTerm.length) {
+            proteinDomain.Ontology_term = OntologyTerm;
+            dbUpdate.$addToSet['attributes.Ontology_term'] = {
+              $each: OntologyTerm,
+            };
+          }
+
+          dbUpdate.$addToSet['subfeatures.$.protein_domains'] = proteinDomain;
+
+          // Binds subfeatures.ID with the seqID of the .gff3 and update.
+          this.bulkOp.find({ 'subfeatures.ID': seqId }).update(dbUpdate);
+        }
+      }
+    }
+  };
+}
+
+export default ParseGff3File;

--- a/imports/api/genes/parseGff3Interproscan.js
+++ b/imports/api/genes/parseGff3Interproscan.js
@@ -59,11 +59,9 @@ class ParseGff3File extends InterproscanProcessor {
             start, end, source, score, name: Name[0],
           };
 
-          // Return only expressions for Interproscan.
           const Dbxref = _dbxref
             .filter((xref) => DBXREF_REGEX.combined.test(xref));
 
-          // Retrieve the interposcan ID (e.g: IPR001048 in InterPro:IPR001048).
           const interproIds = Dbxref
             .filter((xref) => /InterPro/.test(xref))
             .map((interproId) => {
@@ -71,7 +69,6 @@ class ParseGff3File extends InterproscanProcessor {
               return id;
             });
 
-          // Initializes the interproId and signatureDescription keys in proteinDomain.
           if (interproIds.length) {
             proteinDomain.interproId = interproIds[0];
           } else {
@@ -82,14 +79,11 @@ class ParseGff3File extends InterproscanProcessor {
             proteinDomain.signature_desc = signatureDescription[0];
           }
 
-          // Add array of Dbxref (e.g : InterPro:IPR002376, KEGG:00670+2.1.2.9) in
-          // proteinDomain and database.
           if (Dbxref.length) {
             proteinDomain.Dbxref = Dbxref;
             dbUpdate.$addToSet['attributes.Dbxref'] = { $each: Dbxref };
           }
 
-          // e.g: GO:0009058","GO:0016742.
           if (OntologyTerm.length) {
             proteinDomain.Ontology_term = OntologyTerm;
             dbUpdate.$addToSet['attributes.Ontology_term'] = {
@@ -98,8 +92,6 @@ class ParseGff3File extends InterproscanProcessor {
           }
 
           dbUpdate.$addToSet['subfeatures.$.protein_domains'] = proteinDomain;
-
-          // Binds subfeatures.ID with the seqID of the .gff3 and update.
           this.bulkOp.find({ 'subfeatures.ID': seqId }).update(dbUpdate);
         }
       }

--- a/imports/api/genes/parseGff3Interproscan.js
+++ b/imports/api/genes/parseGff3Interproscan.js
@@ -1,4 +1,4 @@
-import { InitializeGenes } from '/imports/api/genes/addInterproscan.js';
+import { InterproscanProcessor } from '/imports/api/genes/addInterproscan.js';
 import { Meteor } from 'meteor/meteor';
 import logger from '/imports/api/util/logger.js';
 import {
@@ -15,7 +15,7 @@ const logAttributeError = ({
   throw new Meteor.Error(error);
 };
 
-class ParseGff3File extends InitializeGenes {
+class ParseGff3File extends InterproscanProcessor {
   isProteinMatch = (type) => {
     if (type === 'protein_match') {
       return true;

--- a/imports/api/genes/parseTsvInterproscan.js
+++ b/imports/api/genes/parseTsvInterproscan.js
@@ -1,7 +1,7 @@
-import { InitializeGenes } from '/imports/api/genes/addInterproscan.js';
+import { InterproscanProcessor } from '/imports/api/genes/addInterproscan.js';
 import logger from '/imports/api/util/logger.js';
 
-class ParseTsvFile extends InitializeGenes {
+class ParseTsvFile extends InterproscanProcessor {
   parse = (line) => {
     const [
       seqId,

--- a/imports/api/genes/parseTsvInterproscan.js
+++ b/imports/api/genes/parseTsvInterproscan.js
@@ -1,0 +1,62 @@
+import { InitializeGenes } from '/imports/api/genes/addInterproscan.js';
+import logger from '/imports/api/util/logger.js';
+
+class ParseTsvFile extends InitializeGenes {
+  parse = (line) => {
+    const [
+      seqId,
+      md5,
+      length,
+      analysis, // source (gff3)
+      signatureAccession, // Name (gff3)
+      signatureDescription, // signature_desc (gff3)
+      start,
+      stop, // end (gff3)
+      score,
+      status,
+      date,
+      interproAccession, // interproIds (gff3)
+      interpro_description, // signature_desc (gff3)
+      goAnnotation, // Ontology_term (referring to a GO association) (gff3)
+      pathwaysAnnotations, // Dbxref (gff3)
+    ] = line.split('\t');
+
+    const dbUpdate = { $addToSet: {} };
+
+    const proteinDomain = {
+      start, end: stop, source: analysis, score, name: signatureAccession,
+    };
+
+    const ontologyTerm = (goAnnotation === undefined ? '' : goAnnotation.split('|'));
+    const Dbxref = (pathwaysAnnotations === undefined ? '' : pathwaysAnnotations.split('|'));
+
+    if (interproAccession.length && interproAccession !== '-') {
+      const interproscanLabel = ''.concat('InterPro:', interproAccession);
+      Dbxref.unshift(interproscanLabel);
+      proteinDomain.interproId = interproAccession;
+    } else {
+      proteinDomain.interproId = 'Unintegrated signature';
+    }
+
+    if (signatureDescription.length && signatureDescription !== '-') {
+      proteinDomain.signature_desc = signatureDescription;
+    }
+
+    if (Dbxref.length && Dbxref !== '-') {
+      proteinDomain.Dbxref = Dbxref;
+      dbUpdate.$addToSet['attributes.Dbxref'] = { $each: Dbxref };
+    }
+
+    if (ontologyTerm.length && ontologyTerm !== '-') {
+      proteinDomain.Ontology_term = ontologyTerm;
+      dbUpdate.$addToSet['attributes.Ontology_term'] = {
+        $each: ontologyTerm,
+      };
+    }
+
+    dbUpdate.$addToSet['subfeatures.$.protein_domains'] = proteinDomain;
+    this.bulkOp.find({ 'subfeatures.ID': seqId }).update(dbUpdate);
+  };
+}
+
+export default ParseTsvFile;

--- a/imports/api/jobqueue/process-interproscan.js
+++ b/imports/api/jobqueue/process-interproscan.js
@@ -12,7 +12,7 @@ jobQueue.processJobs(
     payload: 1,
   },
   async (job, callback) => {
-    const { fileName, formatOutput } = job.data;
+    const { fileName, parser } = job.data;
     logger.log(`Add ${fileName} interproscan file.`);
 
     const rl = readline.createInterface({
@@ -21,12 +21,12 @@ jobQueue.processJobs(
     });
 
     let lineProcessor;
-    switch (formatOutput) {
-      case '.tsv':
+    switch (parser) {
+      case 'tsv':
         logger.log('Format : .tsv');
         lineProcessor = new ParseTsvFile();
         break;
-      case '.gff3':
+      case 'gff3':
         logger.log('Format : .gff3');
         lineProcessor = new ParseGff3File();
         break;
@@ -34,7 +34,6 @@ jobQueue.processJobs(
 
     let lineNbr = 0;
 
-    // https://stackoverflow.com/questions/6156501/read-a-file-one-line-at-a-time-in-node-js
     rl.on('line', async (line) => {
       lineNbr += 1;
 
@@ -51,7 +50,7 @@ jobQueue.processJobs(
       }
     });
 
-    // Occurrs when all lines are read.
+    // Occurs when all lines are read.
     rl.on('close', async () => {
       try {
         logger.log('File reading finished');

--- a/imports/api/jobqueue/process-interproscan.js
+++ b/imports/api/jobqueue/process-interproscan.js
@@ -54,8 +54,10 @@ jobQueue.processJobs(
     rl.on('close', async () => {
       try {
         logger.log('File reading finished');
-        await lineProcessor.finalize();
-        job.done();
+        const { nMatched } = await lineProcessor.finalize();
+        const nInserted = nMatched;
+        logger.log(`Matched to ${nMatched} protein domain(s)`);
+        job.done({ nInserted });
       } catch (err) {
         logger.error(err);
         job.fail({ err });

--- a/imports/api/jobqueue/process-interproscan.js
+++ b/imports/api/jobqueue/process-interproscan.js
@@ -1,16 +1,67 @@
-import { Meteor } from 'meteor/meteor';
+import ParseGff3File from '/imports/api/genes/parseGff3Interproscan.js';
+import ParseTsvFile from '/imports/api/genes/parseTsvInterproscan.js';
+import logger from '/imports/api/util/logger.js';
 import jobQueue from './jobqueue.js';
+import readline from 'readline';
+import fs from 'fs';
 
-const queue = jobQueue.processJobs(
-  'interproscan',
+jobQueue.processJobs(
+  'addInterproscan',
   {
     concurrency: 4,
-    payload: 1
+    payload: 1,
   },
-  function(job, callback){
-    console.log(job.data.geneId)
-    //Meteor.call('interproscan',job.data.geneId)
-    job.done()
-    callback()
-  })
+  async (job, callback) => {
+    const { fileName, formatOutput } = job.data;
+    logger.log(`Add ${fileName} interproscan file.`);
 
+    const rl = readline.createInterface({
+      input: fs.createReadStream(fileName, 'utf8'),
+      crlfDelay: Infinity,
+    });
+
+    let lineProcessor;
+    switch (formatOutput) {
+      case '.tsv':
+        logger.log('Format : .tsv');
+        lineProcessor = new ParseTsvFile();
+        break;
+      case '.gff3':
+        logger.log('Format : .gff3');
+        lineProcessor = new ParseGff3File();
+        break;
+    }
+
+    let lineNbr = 0;
+
+    // https://stackoverflow.com/questions/6156501/read-a-file-one-line-at-a-time-in-node-js
+    rl.on('line', async (line) => {
+      lineNbr += 1;
+
+      if (lineNbr % 10000 === 0) {
+        logger.debug(`Processed ${lineNbr} lines`);
+      }
+
+      try {
+        lineProcessor.parse(line);
+      } catch (err) {
+        logger.error(err);
+        job.fail({ err });
+        callback();
+      }
+    });
+
+    // Occurrs when all lines are read.
+    rl.on('close', async () => {
+      try {
+        logger.log('File reading finished');
+        await lineProcessor.finalize();
+        job.done();
+      } catch (err) {
+        logger.error(err);
+        job.fail({ err });
+      }
+      callback();
+    });
+  },
+);


### PR DESCRIPTION
Hi @holmrenser,
In this new PR, I focused on new functionality for interproscan, I added:
- The ability to read an interproscan output file in **.tsv format** and update the database,
- The interproscan CLI command **add interproscan** becomes a job queue,
- Moreover, the files are read line by line split by tabulation, to avoid errors in loading files that are too large (> 512 MB with fs.readFileSync) in memory.